### PR TITLE
Update CmakeLists.txt add opus to link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(voip_perf
 	pthread
 	m
 	asound
+	opus
 )
 
 #target_link_libraries(voip_perf


### PR DESCRIPTION
needed to compile, at least on ubuntu 16.04 fully updated. Maybe pjsua added OPUS, or maybe configure found opus on my machine? Anyway, without adding it, voip_perf does not compile
Thanks for this tool!