### PR TITLE
contact user randomized

### DIFF
--- a/src/voip_perf.c
+++ b/src/voip_perf.c
@@ -1380,6 +1380,9 @@ static pj_status_t make_call(const pj_str_t *dst_uri) {
 		}
 	} while (ret);
 
+	// contact same as from-uri
+	app.local_contact = local_uri;
+
 	/* Create UAC dialog */
 	status = pjsip_dlg_create_uac( pjsip_ua_instance(), 
 				   &local_uri,		/* local URI	    */


### PR DESCRIPTION
hello, 
I found that if user part of the From header contains "?" and will be replaced by random digits the user part of Contact header is not being randomized and will contain "?" in the header. So this is a small fix.
Thank you for this tool. 