### PR TITLE
Include digit '9' in random number generation.

### DIFF
--- a/src/voip_perf.c
+++ b/src/voip_perf.c
@@ -1377,14 +1377,14 @@ static pj_status_t make_call(const pj_str_t *dst_uri) {
 	do {
 		ret = strstr(target_uri.ptr, c);
 			if (ret) {
-			ret[0] = digit[rand()%9];
+			ret[0] = digit[rand()%10];
 		}
 	} while (ret);
 
 	do {
 		ret = strstr(local_uri.ptr, c);
 			if (ret) {
-			ret[0] = digit[rand()%9];
+			ret[0] = digit[rand()%10];
 		}
 	} while (ret);
 


### PR DESCRIPTION
I noticed when analyzing cdr's from inbound block testing that no numbers including 9 were generated dynamically. I was also using modulo for assigning routes within the block so I was missing 1/10th of my expected route's getting hit.